### PR TITLE
org-babel-hy-evaluate-external-process fix command quoting

### DIFF
--- a/ob-hy.el
+++ b/ob-hy.el
@@ -142,18 +142,22 @@ last statement in BODY, as elisp."
   (let ((result
          (pcase result-type
            (`output (org-babel-eval
-                     (format "%s -c '%s'" org-babel-hy-command body) ""))
+                     (format "%s -c %s"
+                             org-babel-hy-command
+                             (combine-and-quote-strings (list body))) ""))
            (`value (let ((tmp-file (org-babel-temp-file "hy-")))
                      (org-babel-eval
                       (format
-                       "%s -c '%s'"
+                       "%s -c %s"
                        org-babel-hy-command
-                       (format
-                        (if (member "pp" result-params)
-                            org-babel-hy-pp-wrapper-method
-                          org-babel-hy-wrapper-method)
-                        body
-                        (org-babel-process-file-name tmp-file 'noquote))) "")
+                       (combine-and-quote-strings
+                        (list
+                         (format
+                          (if (member "pp" result-params)
+                              org-babel-hy-pp-wrapper-method
+                            org-babel-hy-wrapper-method)
+                          body
+                          (org-babel-process-file-name tmp-file 'noquote))))) "")
                      (org-babel-eval-read-file tmp-file))))))
     (org-babel-result-cond result-params
       result


### PR DESCRIPTION
Replace single quotes with combine-and-quote-strings when passing
source code to org-babel-eval.

hy source blocks were passed to orb-babel-eval using a pair of single
quotes, which meant that if a quote was used in a source block it
would end the string and the rest of the source block would be fed
directly to the shell used by org-babel-eval.